### PR TITLE
cohttp-eio: simplify Server.run

### DIFF
--- a/cohttp-eio/examples/server1.ml
+++ b/cohttp-eio/examples/server1.ml
@@ -34,7 +34,6 @@ let app req =
   match Request.resource req with
   | "/" -> Response.text text
   | "/html" -> Response.html text
-  | "/exit" -> exit 0
   | _ -> Response.not_found
 
 let () =
@@ -43,5 +42,5 @@ let () =
     [ ("-p", Arg.Set_int port, " Listening port number(8080 by default)") ]
     ignore "An HTTP/1.1 server";
 
-  let server = Server.create ~port:!port app ~socket_backlog:128 in
-  Eio_linux.run @@ fun env -> Server.run server (env :> Eio.Stdenv.t)
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw -> Server.run ~port:!port env sw app

--- a/cohttp-eio/src/cohttp_eio.mli
+++ b/cohttp-eio/src/cohttp_eio.mli
@@ -61,6 +61,9 @@ module Request : sig
       custom request body reader. *)
 
   val set_read_complete : t -> unit
+  (** [set_read_complete t] configures [t] to denote that reading of request
+      body is complete. Call this function if you are using a custom request
+      body processor. *)
 
   (** {1 Pretty Printer} *)
 
@@ -107,14 +110,19 @@ end
 
 (** [Server] is a HTTP 1.1 server. *)
 module Server : sig
-  type t
   type handler = Request.t -> Response.t
   type middleware = handler -> handler
 
   (** {1 Run Server} *)
 
-  val create : ?socket_backlog:int -> ?domains:int -> port:int -> handler -> t
-  val run : t -> Eio.Stdenv.t -> unit
+  val run :
+    ?socket_backlog:int ->
+    ?domains:int ->
+    port:int ->
+    Eio.Stdenv.t ->
+    Eio.Switch.t ->
+    handler ->
+    unit
 
   (** {1 Basic Handlers} *)
 
@@ -123,6 +131,7 @@ end
 
 (**/**)
 
+(** Do not use directly. Used for unit testing only. *)
 module Private : sig
   val create_reader : int -> Eio.Flow.source -> Reader.t
   val commit_reader : Reader.t -> unit

--- a/cohttp-eio/src/server.ml
+++ b/cohttp-eio/src/server.ml
@@ -3,22 +3,15 @@ open Eio.Std
 type handler = Request.t -> Response.t
 type middleware = handler -> handler
 
-type t = {
-  socket_backlog : int;
-  domains : int;
-  port : int;
-  request_handler : handler;
-}
-
 let domain_count =
   match Sys.getenv_opt "COHTTP_DOMAINS" with
   | Some d -> int_of_string d
   | None -> 1
 
-let rec handle_request t reader writer flow =
+let rec handle_request reader writer flow handler =
   match Request.parse reader with
   | request ->
-      let response = t.request_handler request in
+      let response = handler request in
       Response.write response writer;
       Writer.wakeup writer;
       if Request.is_keep_alive request then (
@@ -27,7 +20,7 @@ let rec handle_request t reader writer flow =
          | Http.Transfer.Fixed _ -> ignore @@ Request.read_fixed request
          | Http.Transfer.Chunked -> ignore @@ Request.read_chunk request ignore
          | _ -> ());
-        handle_request t reader writer flow)
+        handle_request reader writer flow handler)
       else Eio.Flow.close flow
   | (exception End_of_file) | (exception Eio.Net.Connection_reset _) ->
       Eio.Flow.close flow
@@ -40,7 +33,7 @@ let rec handle_request t reader writer flow =
       Writer.wakeup writer;
       Eio.Flow.close flow
 
-let run_domain (t : t) ssock =
+let run_domain ssock handler =
   let on_accept_error exn =
     Printf.fprintf stderr "Error while accepting connection: %s"
       (Printexc.to_string exn)
@@ -52,27 +45,21 @@ let run_domain (t : t) ssock =
             let reader = Reader.create 0x1000 (flow :> Eio.Flow.source) in
             let writer = Writer.create flow in
             Eio.Fiber.fork ~sw (fun () -> Writer.run writer);
-            handle_request t reader writer flow)
+            handle_request reader writer flow handler)
       done)
 
-let create ?(socket_backlog = 128) ?(domains = domain_count) ~port
-    request_handler =
-  { socket_backlog; domains; port; request_handler }
-
-(* wrk2 -t 24 -c 1000 -d 60s -R400000 http://localhost:8080 *)
-let run (t : t) (env : Eio.Stdenv.t) =
-  Switch.run @@ fun sw ->
+let run ?(socket_backlog = 128) ?(domains = domain_count) ~port env sw handler =
   let domain_mgr = Eio.Stdenv.domain_mgr env in
   let ssock =
     Eio.Net.listen (Eio.Stdenv.net env) ~sw ~reuse_addr:true ~reuse_port:true
-      ~backlog:t.socket_backlog
-      (`Tcp (Eio.Net.Ipaddr.V4.loopback, t.port))
+      ~backlog:socket_backlog
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
   in
-  for _ = 2 to t.domains do
+  for _ = 2 to domains do
     Eio.Std.Fiber.fork ~sw (fun () ->
-        Eio.Domain_manager.run domain_mgr (fun () -> run_domain t ssock))
+        Eio.Domain_manager.run domain_mgr (fun () -> run_domain ssock handler))
   done;
-  run_domain t ssock
+  run_domain ssock handler
 
 (* Basic handlers *)
 

--- a/cohttp-eio/tests/test_chunk_server.ml
+++ b/cohttp-eio/tests/test_chunk_server.ml
@@ -22,5 +22,5 @@ let () =
     [ ("-p", Arg.Set_int port, " Listening port number(8080 by default)") ]
     ignore "An HTTP/1.1 server";
 
-  let server = Server.create ~port:!port app in
-  Eio_main.run @@ fun env -> Server.run server (env :> Eio.Stdenv.t)
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw -> Server.run ~port:!port env sw app

--- a/cohttp-eio/tests/test_server.ml
+++ b/cohttp-eio/tests/test_server.ml
@@ -9,5 +9,5 @@ let app req =
   Response.text (Buffer.contents buf)
 
 let () =
-  let server = Server.create ~port:8080 app ~socket_backlog:128 in
-  Eio_main.run @@ fun env -> Server.run server (env :> Eio.Stdenv.t)
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw -> Server.run ~port:8080 env sw app


### PR DESCRIPTION
Remove redundant `Server.t` type since we don't need it now.
Previously it was needed for implementing `stop` but now that
functionality is moved to consumers of `cohttp-eio`. This can easily
be implemented using `Eio.Switch.fail` api.