### PR TITLE
Expose Response.create and wakeup writer earlier for custom responses

### DIFF
--- a/cohttp-eio/src/cohttp_eio.mli
+++ b/cohttp-eio/src/cohttp_eio.mli
@@ -90,6 +90,7 @@ module Server : sig
     (** {1 Configuring Basic Response} *)
 
     val create : ?version:Http.Version.t -> ?status:Http.Status.t -> ?headers:Http.Header.t -> body -> t
+    (** [create body] returns a HTTP/1.1, 200 status response with no headers. *)
 
     val text : string -> t
     (** [text t s] returns a HTTP/1.1, 200 status response with "Content-Type"

--- a/cohttp-eio/src/cohttp_eio.mli
+++ b/cohttp-eio/src/cohttp_eio.mli
@@ -89,6 +89,8 @@ module Server : sig
 
     (** {1 Configuring Basic Response} *)
 
+    val create : ?version:Http.Version.t -> ?status:Http.Status.t -> ?headers:Http.Header.t -> body -> t
+
     val text : string -> t
     (** [text t s] returns a HTTP/1.1, 200 status response with "Content-Type"
         header set to "text/plain". *)

--- a/cohttp-eio/src/response.ml
+++ b/cohttp-eio/src/response.ml
@@ -66,7 +66,9 @@ let write t writer =
   Writer.write_string writer "\r\n";
   match t.body with
   | String s -> Writer.write_string writer s
-  | Custom f -> f (Writer.sink writer)
+  | Custom f -> 
+    Writer.wakeup writer;
+    f (Writer.sink writer)
   | Chunked chunk_writer -> write_chunked (Writer.sink writer) chunk_writer
   | Empty -> ()
 


### PR DESCRIPTION
Whilst porting [ocaml-websocket](https://github.com/vbmithr/ocaml-websocket/) to direct-style using `eio` and `cohttp-eio` I needed to: 

 - Expose lower-level response creation in order to use a `Custom f` body type.
 - I also had to wake the writer before using the custom body response -- this seems to match how this works in the `lwt` version as far as I can tell, where the [Response header is written first](https://github.com/mirage/ocaml-cohttp/blob/0a586d77aba15f62518f679600d961f7b26be070/cohttp-lwt/src/server.ml#L133), although I'm not very familiar with the codebase so I might have just been doing something incorrect.
